### PR TITLE
Require stable version of projectcleverweb/php-uri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.4",
 		"digitalnature/php-ref": "dev-master",
-		"projectcleverweb/php-uri": "dev-develop",
+		"projectcleverweb/php-uri": "~1.0.0",
 		"cebe/markdown": "~1.0.1",
 		"milo/github-api": "^1.4"
 	},


### PR DESCRIPTION
Otherwise composer may fail to install because of minimum-stability